### PR TITLE
feat: add ServerBindAddr to app examples, fixes #40

### DIFF
--- a/app-services/advanced-filter-convert-publish/res/configuration.toml
+++ b/app-services/advanced-filter-convert-publish/res/configuration.toml
@@ -10,6 +10,7 @@ BootTimeout = '30s'
 ClientMonitor = '15s'
 CheckInterval = '10s'
 Host = 'localhost'
+ServerBindAddr = "" # if blank, uses default Go behavior https://golang.org/pkg/net/#Listen
 Port = 48095
 Protocol = 'http'
 ReadMaxLimit = 100

--- a/app-services/advanced-target-type/res/configuration.toml
+++ b/app-services/advanced-target-type/res/configuration.toml
@@ -10,6 +10,7 @@ BootTimeout = '30s'
 ClientMonitor = '15s'
 CheckInterval = '10s'
 Host = 'localhost'
+ServerBindAddr = "" # if blank, uses default Go behavior https://golang.org/pkg/net/#Listen
 Port = 48095
 Protocol = 'http'
 ReadMaxLimit = 100

--- a/app-services/app-functions-aws/res/configuration.toml
+++ b/app-services/app-functions-aws/res/configuration.toml
@@ -6,6 +6,7 @@ BootTimeout = '30s'
 ClientMonitor = '15s'
 CheckInterval = '10s'
 Host = 'localhost'
+ServerBindAddr = "" # if blank, uses default Go behavior https://golang.org/pkg/net/#Listen
 Port = 48095
 Protocol = 'http'
 ReadMaxLimit = 100

--- a/app-services/app-functions-azure/res/configuration.toml
+++ b/app-services/app-functions-azure/res/configuration.toml
@@ -6,6 +6,7 @@ BootTimeout = '30s'
 ClientMonitor = '15s'
 CheckInterval = '10s'
 Host = 'localhost'
+ServerBindAddr = "" # if blank, uses default Go behavior https://golang.org/pkg/net/#Listen
 Port = 48095
 Protocol = 'http'
 ReadMaxLimit = 100

--- a/app-services/cloud-event-transforms/res/configuration.toml
+++ b/app-services/cloud-event-transforms/res/configuration.toml
@@ -6,6 +6,7 @@ BootTimeout = '30s'
 ClientMonitor = '15s'
 CheckInterval = '10s'
 Host = 'localhost'
+ServerBindAddr = "" # if blank, uses default Go behavior https://golang.org/pkg/net/#Listen
 Port = 48095
 Protocol = 'http'
 ReadMaxLimit = 100

--- a/app-services/http-command-service/res/configuration.toml
+++ b/app-services/http-command-service/res/configuration.toml
@@ -10,6 +10,7 @@ BootTimeout = '30s'
 ClientMonitor = '15s'
 CheckInterval = '10s'
 Host = 'localhost'
+ServerBindAddr = "" # if blank, uses default Go behavior https://golang.org/pkg/net/#Listen
 Port = 48095
 Protocol = 'http'
 ReadMaxLimit = 100

--- a/app-services/json-logic/res/configuration.toml
+++ b/app-services/json-logic/res/configuration.toml
@@ -10,6 +10,7 @@ BootTimeout = '30s'
 ClientMonitor = '15s'
 CheckInterval = '10s'
 Host = 'localhost'
+ServerBindAddr = "" # if blank, uses default Go behavior https://golang.org/pkg/net/#Listen
 Port = 48095
 Protocol = 'http'
 ReadMaxLimit = 100

--- a/app-services/secrets/res/configuration.toml
+++ b/app-services/secrets/res/configuration.toml
@@ -36,6 +36,7 @@ BootTimeout = '30s'
 ClientMonitor = '15s'
 CheckInterval = '10s'
 Host = 'localhost'
+ServerBindAddr = "" # if blank, uses default Go behavior https://golang.org/pkg/net/#Listen
 Port = 48095
 Protocol = 'http'
 ReadMaxLimit = 100

--- a/app-services/simple-cbor-filter/res/configuration.toml
+++ b/app-services/simple-cbor-filter/res/configuration.toml
@@ -10,6 +10,7 @@ BootTimeout = '30s'
 ClientMonitor = '15s'
 CheckInterval = '10s'
 Host = 'localhost'
+ServerBindAddr = "" # if blank, uses default Go behavior https://golang.org/pkg/net/#Listen
 Port = 48095
 Protocol = 'http'
 ReadMaxLimit = 100

--- a/app-services/simple-filter-xml-mqtt/res/configuration.toml
+++ b/app-services/simple-filter-xml-mqtt/res/configuration.toml
@@ -10,6 +10,7 @@ BootTimeout = '30s'
 ClientMonitor = '15s'
 CheckInterval = '10s'
 Host = 'localhost'
+ServerBindAddr = "" # if blank, uses default Go behavior https://golang.org/pkg/net/#Listen
 Port = 48095
 Protocol = 'http'
 ReadMaxLimit = 100

--- a/app-services/simple-filter-xml-post/res/configuration.toml
+++ b/app-services/simple-filter-xml-post/res/configuration.toml
@@ -10,6 +10,7 @@ BootTimeout = '30s'
 ClientMonitor = '15s'
 CheckInterval = '10s'
 Host = 'localhost'
+ServerBindAddr = "" # if blank, uses default Go behavior https://golang.org/pkg/net/#Listen
 Port = 48095
 Protocol = 'http'
 ReadMaxLimit = 100

--- a/app-services/simple-filter-xml/res/configuration.toml
+++ b/app-services/simple-filter-xml/res/configuration.toml
@@ -10,6 +10,7 @@ BootTimeout = '30s'
 ClientMonitor = '15s'
 CheckInterval = '10s'
 Host = 'localhost'
+ServerBindAddr = "" # if blank, uses default Go behavior https://golang.org/pkg/net/#Listen
 Port = 48095
 Protocol = 'http'
 ReadMaxLimit = 100

--- a/configurable-app-services/app-service-configurable-ibm/res/ibm-mqtt-export/configuration.toml
+++ b/configurable-app-services/app-service-configurable-ibm/res/ibm-mqtt-export/configuration.toml
@@ -33,6 +33,7 @@ BootTimeout = 30000
 ClientMonitor = 15000
 CheckInterval = "10s"
 Host = "app-service-configurable-mqtt-export"
+ServerBindAddr = "" # if blank, uses default Go behavior https://golang.org/pkg/net/#Listen
 Port = 48095
 Protocol = "http"
 ReadMaxLimit = 100

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/cloudevents/sdk-go v1.1.2
 	github.com/dghubble/sling v1.3.0
-	github.com/edgexfoundry/app-functions-sdk-go v1.0.1-dev.43
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.57
-	github.com/stretchr/testify v1.5.1
+	github.com/edgexfoundry/app-functions-sdk-go v1.2.1-dev.9
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.60
+	github.com/stretchr/testify v1.6.1
 )


### PR DESCRIPTION
Signed-off-by: charles-knox-intel <44684517+charles-knox-intel@users.noreply.github.com>

Adds the `ServerBindAddr` changes from https://github.com/edgexfoundry/app-functions-sdk-go/pull/409 and https://github.com/edgexfoundry/app-functions-sdk-go/issues/405